### PR TITLE
Configurar acesso a rotas públicas e privadas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,8 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
+/config/local_env.yml
+
 # Ignore coverage
 coverage
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,10 +3,18 @@ class ApplicationController < ActionController::Base
   rescue_from ActionController::RoutingError,  with: :route_not_found
   rescue_from ActionController::UnknownFormat, with: :route_not_found
   protect_from_forgery with: :exception
+  before_action :require_login
   include SessionsHelper
-
 
   def route_not_found
     render file: Rails.public_path.join('404.html'), status: :not_found, layout: false
+  end
+
+  private
+  def require_login
+    unless logged_in?
+      flash.now.alert = 'You must be logged in to access this section'
+      redirect_to login_path, notice: 'You must be logged in to access this section'
+    end
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,4 +1,6 @@
 class PagesController < ApplicationController
-    def home        
-    end
+  skip_before_action :require_login, only: [:home]
+
+  def home
+  end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,4 +1,6 @@
 class SessionsController < ApplicationController
+  skip_before_action :require_login, only: [:new, :create]
+
   def new
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,23 +1,25 @@
 class UsersController < ApplicationController
-    def new
-        @user = User.new
-    end
-    
-    def create
-        @user = User.new(user_params)
-        if @user.save
-            redirect_to login_path, notice: 'User created successfully'
-        else
-            render :new, status: :unprocessable_entity, content_type: "text/html"
-            headers["Content-Type"] = "text/html"
-        end
-    end
+  skip_before_action :require_login, only: [:new, :create]
 
-    private
-    def user_params
-        params
-            .require(:user)
-            .permit(:name, :email, :password, :password_confirmation, :birth_date, :position)
-        
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to login_path, notice: 'User created successfully'
+    else
+      render :new, status: :unprocessable_entity, content_type: 'text/html'
+      headers['Content-Type'] = 'text/html'
     end
+  end
+
+  private
+
+  def user_params
+    params
+      .require(:user)
+      .permit(:name, :email, :password, :password_confirmation, :birth_date, :position)  
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,9 +11,7 @@
   </head>
 
   <body>
-    <% if logged_in? %>
-      <%= link_to "Log out", logout_path, method: :delete %>
-    <% end %>
+    <%= render "shared/header" %>
     <% flash.each do |message_type, message| %>
       <div class="alert alert-<%= message_type %>"><%= message %></div>
     <% end %>

--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -27,6 +27,4 @@
     <%= form.label :level %>
     <%= form.text_field :level %>
     <%= form.submit 'Salvar'%>
-
-    <%= link_to 'View matches', matches_path %>
 <% end %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -7,6 +7,4 @@
   <p><strong>Private court:</strong> <%= @match.privateCourt %></p>
   <p><strong>Half court:</strong> <%= @match.halfCourt %></p>
   <p><strong>Level:</strong> <%= @match.level %></p>
-
-  <%= link_to 'View matches', matches_path %>
 </section>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -12,9 +12,5 @@
     <p>Matheus Aranha Lopes	11221219</p>
     <p>Wallace Ramon Nogueira Soares 11847030</p>
     <p>Thais Lasso Terense 10724222</p>
-
-    <%= link_to 'Sign up', signup_path %>
-    <%= link_to 'Login', login_path %>
-    <%= link_to 'View matches', matches_path %>
   </div>
 </div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -18,4 +18,4 @@
 
 <% end %>
 
-<p>New user? <%= link_to "Sign up", signup_path %></p>
+<p>New user? <%= link_to "Sign up here", signup_path %></p>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,17 @@
+<header>
+    <div>
+        <nav>
+            <ul>
+                <li><%= link_to 'Home', root_path %></li>
+                <% if logged_in? %>
+                    <li><%= link_to "View matches", matches_path %></li>
+                    <li><%= link_to "Create match", new_match_path %></li>
+                    <li><%= link_to "Log out", logout_path, method: :delete %></li>
+                <% else %>
+                    <li><%= link_to 'Login', login_path %></li>
+                    <li><%= link_to 'Sign up', signup_path %></li>
+                <% end %>
+            </ul>
+        </nav>
+    </div>
+</header>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -47,5 +47,5 @@
         <%= form.submit 'Salvar' %>
     </p>
 
-    <p>Already registered? <%= link_to 'Login', login_path %>
+    <p>Already registered? <%= link_to 'Login here', login_path %>
 <% end %>

--- a/features/create_match.feature
+++ b/features/create_match.feature
@@ -1,3 +1,4 @@
+@loginAsUser
 Feature: User creates a match in the app
   The user fills in a form with the match details and makes it available for other users to participate
 

--- a/features/create_rules_in_the_match_creation.feature
+++ b/features/create_rules_in_the_match_creation.feature
@@ -1,3 +1,4 @@
+@loginAsUser
 Feature: User try to create a match in the app but failed
   The user fills in a form with the match details and makes it available for other users to participate. In this case some fields should be mandatory.
 

--- a/features/navigate_between_pages.feature
+++ b/features/navigate_between_pages.feature
@@ -2,21 +2,24 @@
 Feature: User navigate between pages
   The user must be able to navigate between pages
 
+  @loginAsUser
   Scenario: user can go from home to matches page
     Given that the user is in the homepage
     When the user click on "View matches"
     Then the user should be redirected to the matches page
 
+	@loginAsUser
   Scenario: user can go from match creation page to matches page
     Given the user is in the page's match registration
     When the user click on "View matches"
     Then the user should be redirected to the matches page
-    
+  
+	@loginAsUser
   Scenario: user can go from specific match to matches page
     Given that the user visits an existing room
     When the user click on "View matches"
     Then the user should be redirected to the matches page
-    
+  
   Scenario: user can go from home page to sign up page
     Given that the user is in the homepage
     When the user click on "Sign up"

--- a/features/navigate_between_pages.feature
+++ b/features/navigate_between_pages.feature
@@ -8,7 +8,7 @@ Feature: User navigate between pages
     When the user click on "View matches"
     Then the user should be redirected to the matches page
 
-	@loginAsUser
+  @loginAsUser
   Scenario: user can go from match creation page to matches page
     Given the user is in the page's match registration
     When the user click on "View matches"

--- a/features/private_and_public_routes.feature
+++ b/features/private_and_public_routes.feature
@@ -1,0 +1,24 @@
+Feature: Private and public routes
+  The user wants to access and handle some private resource
+
+  Scenario: User not logged in
+    Given that the user is not logged in
+    Then the user should see the link for 'Home' in the header
+    Then the user should see the link for 'Login' in the header
+    Then the user should see the link for 'Sign up' in the header
+    When the user tries to access the link '/matches'
+    When the user tries to access the link '/matches/new'
+    Then the user should be redirected to login page
+    And the user see the message "You must be logged in to access this section"
+  
+  Scenario: User logged in
+    Given that the user is logged in
+    Then the user should see the link for 'Home' in the header
+    Then the user should see the link for 'View matches' in the header
+    Then the user should see the link for 'Create match' in the header
+    Then the user should see the link for 'Log out' in the header
+    When the user tries to access the link '/matches'
+    When the user tries to access the link '/matches/new'
+    Then the user should be redirected to the desired page
+  
+  

--- a/features/search_match.feature
+++ b/features/search_match.feature
@@ -1,3 +1,4 @@
+@loginAsUser
 Feature: Search matches
 
 Scenario: See all matches

--- a/features/see_match.feature
+++ b/features/see_match.feature
@@ -1,4 +1,5 @@
 @oneMatchBefore
+@loginAsUser
 Feature: User visits specific match
   The user can see a specific match and its main information.
 

--- a/features/see_matches.feature
+++ b/features/see_matches.feature
@@ -1,4 +1,5 @@
 @oneMatchBefore
+@loginAsUser
 Feature: User visits list of matches
   The user can view, enter and create new matches
   

--- a/features/step_definitions/create_match.rb
+++ b/features/step_definitions/create_match.rb
@@ -1,5 +1,5 @@
 Given("the user is in the page's match registration") do
-    visit '/matches/new'
+  visit '/matches/new'
 end
 
 When('the user click on the {string} field selecting the checkbox to {string}') do |string, string2|

--- a/features/step_definitions/private_and_public_routes_steps.rb
+++ b/features/step_definitions/private_and_public_routes_steps.rb
@@ -1,0 +1,33 @@
+Given('that the user is not logged in') do
+  visit '/'
+end
+
+Then('the user should see the link for {string} in the header') do |string|
+  expect(page).to  have_content(string)
+end
+
+When('the user tries to access the link {string}') do |string|
+  visit string
+end
+
+Then('the user should be redirected to login page') do
+  expect(page).to  have_content('You must be logged in to access this section')
+  expect(page).to have_current_path(login_path)
+end
+
+
+Given('that the user is logged in') do
+  email = 'test@mail.com'
+  password = '123456'
+
+  user = User.create(name: 'Joao', email: email,  password: password, password_confirmation: password, birth_date: 'Thu, 14 Oct 1999', position: 'Power Forward')
+  
+  visit '/login'
+  fill_in 'session_email', :with => email
+  fill_in 'session_password', :with => password
+  click_on 'Submit'
+end
+
+Then('the user should be redirected to the desired page') do
+  expect(page).not_to be(login_path)
+end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -2,3 +2,13 @@ Before('@oneMatchBefore') do
   @match = Match.create(name: 'Rachao da EACH', description: "Rachao entre alunos da Each", address: "Rua Arlindo Béttio, 1000 - Ermelino Matarazzo, São Paulo - SP, 03828-000", limit: "10", privateCourt: true, halfCourt: true, level: "livre")
 end
 
+Before('@loginAsUser') do
+  email = 'test@mail.com'
+  password = '123456'
+  user = User.create(name: 'Test', email: email,  password: password, password_confirmation: password, birth_date: 'Thu, 14 Oct 1999', position: 'Power Forward')
+  visit '/login'
+  fill_in 'session_email', :with => email
+  fill_in 'session_password', :with => password
+  click_on 'Submit'
+end
+


### PR DESCRIPTION
A ideia dessa funcionalidade é de restrigir o acesso a algumas rotas, de modo que só seja possível acessá-las caso o usuário esteja logado no sistema. Isso envolve, por exemplo, a criação de uma partida, a busca por partidas. Dessa forma, caso o usuário não esteja logado no sistema ele terá acesso somente às rotas públicas que são a página principal, cadastro e login. 